### PR TITLE
Handle preload bytes

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -29,6 +29,8 @@ type entry struct {
 	// If zero, the entire file is stored in the preload data.
 	// Otherwise, the number of bytes stored starting at EntryOffset.
 	entryLength uint32
+
+	preloadDatas []byte
 }
 
 func (e *entry) Filename() string {
@@ -122,9 +124,11 @@ func (e *entry) FilenameSafeWindows() bool {
 func (e *entry) Open() (FileReader, error) {
 	if e.archiveIndex == 0x7fff {
 		return &entryReader{
-			fs:     e.parent.stream,
-			offset: int64(e.parent.headerSize) + int64(e.parent.treeSize) + int64(e.entryOffset),
-			size:   int64(e.entryLength),
+			fs:           e.parent.stream,
+			offset:       int64(e.parent.headerSize) + int64(e.parent.treeSize) + int64(e.entryOffset),
+			size:         int64(e.entryLength + uint32(e.preloadBytes)),
+			preloadBytes: int64(e.preloadBytes),
+			preloadDatas: e.preloadDatas,
 		}, nil
 	}
 
@@ -133,9 +137,11 @@ func (e *entry) Open() (FileReader, error) {
 	}
 
 	return &entryReader{
-		fs:     e.parent.indexes[e.archiveIndex],
-		offset: int64(e.entryOffset),
-		size:   int64(e.entryLength),
+		fs:           e.parent.indexes[e.archiveIndex],
+		offset:       int64(e.entryOffset),
+		size:         int64(e.entryLength + uint32(e.preloadBytes)),
+		preloadBytes: int64(e.preloadBytes),
+		preloadDatas: e.preloadDatas,
 	}, nil
 }
 

--- a/tree.go
+++ b/tree.go
@@ -3,7 +3,6 @@ package vpk
 import (
 	"bufio"
 	"encoding/binary"
-	"errors"
 	"io"
 )
 
@@ -57,7 +56,10 @@ func treeReader(v VPK, reader *bufio.Reader, buffer []byte, cb func(e *entry)) e
 				}
 
 				if entry.preloadBytes > 0 {
-					return errors.New("preload bytes not implemented yet")
+					entry.preloadDatas = make([]byte, entry.preloadBytes)
+					if _, err := io.ReadFull(reader, entry.preloadDatas); err != nil {
+						return err
+					}
 				}
 
 				cb(entry)


### PR DESCRIPTION
Make use of preload bytes

Tested with the l4d2 base game pak. Data set contains 3 types of entries

1. entries with no preload bytes
2. entries entirely contained in the preload bytes
3. entries overlaping preload bytes and regular bytes